### PR TITLE
Autoban Bug Fix: Restrict Autoban Trigger

### DIFF
--- a/mastermelon/anti_mindus_bot.py
+++ b/mastermelon/anti_mindus_bot.py
@@ -3,14 +3,13 @@ import discord
 from datetime import datetime
 
 async def vkick_anti_bot(message,bot,autoban_counts,melonbotmindusbans):
-    if message.author.id == bot.user.id:
-        return
     if "w?sendcmd -1" not in message.content:
         return
     if "ModAdmin Hammer vkick" not in message.content:
         return
     if "Report" in message.content:
         return
+
     autoban_channel: discord.TextChannel = bot.get_channel(1165956715230015529)
     mod_report_channel: discord.TextChannel = bot.get_channel(796305521270587413) 
     autoban_message_ctx = await autoban_channel.fetch_message(1173435083353505792)
@@ -34,15 +33,12 @@ async def vkick_anti_bot(message,bot,autoban_counts,melonbotmindusbans):
         melonbotmindusbans.insert_one( {"date": datetime.now(),"type":"vkick_muuid","banned_user":username,"ban_command":ban_command_muuid,"original_msg":message.content} )
 
 async def plugin_anti_bot(message,bot,autoban_counts,melonbotmindusbans):
-    
-    if message.author.id == bot.user.id:
-        return
     if "BOT detected! IP banned: " not in message.content:
         return
     ip = message.content.split("BOT detected! IP banned: ")[1]
-    
     if message.content.count("BOT detected! IP banned: ")>1:
         return
+
     autoban_channel: discord.TextChannel = bot.get_channel(1165956715230015529)
     autoban_message_ctx = await autoban_channel.fetch_message(1173435083353505792)
     if len(ip.split("."))!=4:

--- a/mastermelon/melon.py
+++ b/mastermelon/melon.py
@@ -41,6 +41,8 @@ MODERATOR_LOGS_CHANNEL = 796305521270587413
 COUNTING_CHANNEL = 805105861450137600
 APPEAL_CHANNEL = 791490149753683988
 
+MINDUS_REPORT_BOT = 796310311376257054
+
 STATUS_MSG_CHANNEL = 791158921443409950
 STATUS_LOG_CHANNEL = 791129836948422676
 
@@ -1238,9 +1240,9 @@ async def on_message(message: discord.Message):
         await message.reply("😊", mention_author=True)
     elif message.content == ':pepoclap:' and prefix == "t?":
         await message.reply(pepo_clap)
-    elif prefix == "w?" and message.channel.id == ADMIN_LOGS_CHANNEL:  # admin logs channel
+    elif prefix == "w?" and message.channel.id == ADMIN_LOGS_CHANNEL and message.author.id == MINDUS_REPORT_BOT:  # admin logs channel
         await vkick_anti_bot(message, bot, autoban_counts, melonbotmindusbans)
-    elif prefix == "w?" and message.channel.id == MODERATOR_LOGS_CHANNEL:  # moderator logs channel
+    elif prefix == "w?" and message.channel.id == MODERATOR_LOGS_CHANNEL and message.author.id == MINDUS_REPORT_BOT:  # moderator logs channel
         await plugin_anti_bot(message, bot, autoban_counts, melonbotmindusbans)
     elif prefix == "w?" and message.channel.id == COUNTING_CHANNEL :  # counting hardcore channel
         if message.author.id != bot.user.id:


### PR DESCRIPTION
## Problem
Anyone in the mod reports channel could send a message like:
`BOT detected! IP banned: 123.251.149.35`
and the system would trust it and ban that IP. This allowed unauthorized bans.

## Cause
The bot only checked if the message wasn’t from itself, and didint check if the message was from a random user.
```
    elif prefix == "w?" and message.channel.id == ADMIN_LOGS_CHANNEL:
```
```
    if message.author.id == bot.user.id:
        return
```

## Fix
We now restrict auto-ban logic to messages only sent by the trusted report bot:

`MINDUS_REPORT_BOT = 796310311376257054`
and
```
    elif prefix == "w?" and message.channel.id == ADMIN_LOGS_CHANNEL and message.author.id == MINDUS_REPORT_BOT:  # admin logs channel
        await vkick_anti_bot(message, bot, autoban_counts, melonbotmindusbans)
    elif prefix == "w?" and message.channel.id == MODERATOR_LOGS_CHANNEL and message.author.id == MINDUS_REPORT_BOT:  # moderator logs channel
        await plugin_anti_bot(message, bot, autoban_counts, melonbotmindusbans)
```


Also when we do that we no longer need to check if the message when send by the bot itself because `report_hook_mods` is not controlled by `watermelonbot`